### PR TITLE
Add support for Interest Categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /tmp/
 *.tags*
 .idea/*
+dev-config.yml
 
 ## Documentation cache and generated files:
 /.yardoc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,5 @@
 ### Added
 - Support of `/`
 - Support of `/lists`
+- Support of '/lists/<id>/interest-categories'
 - `.count` support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mailchimp_api (1.0.0.pre.0)
+    mailchimp_api (1.0.0.pre.1)
       activeresource (~> 5.1.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -45,7 +45,13 @@ account.with_mailchimp_session { MailchimpAPI::List.all }
 
 ## Development
 
-After checking out the repository, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repository, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests.
+
+You can also run `bin/console` for an interactive prompt that will allow you to experiment. You can create a file in the root of the project called `dev-config.yml` and add your API key to it:
+```
+api_key: <your-api-key>
+```
+This will tell the console to pre-authenticate the Mailchimp session, making it easier to test.
 
 ## Contributing
 

--- a/bin/console
+++ b/bin/console
@@ -10,7 +10,13 @@ HttpLogger.logger       = Logger.new STDOUT
 require 'pry'
 Pry.pager = nil
 
-# DO NOT COMMIT YOUR API KEY
-API_KEY = 'xxx'
+require 'yaml'
 
-MailchimpAPI::Session.temp(API_KEY) { Pry.start }
+# Pre-configure playground if they have config file set.
+# Otherwise they are on their own.
+config_file = config = YAML::load(IO.read('./dev-config.yml')) if File.exists? './dev-config.yml'
+if config_file
+  MailchimpAPI::Session.temp(config_file['api_key']) { Pry.start }
+else
+  Pry.start
+end

--- a/bin/console
+++ b/bin/console
@@ -7,8 +7,10 @@ require 'http_logger'
 HttpLogger.log_headers  = true
 HttpLogger.logger       = Logger.new STDOUT
 
-
 require 'pry'
 Pry.pager = nil
 
-Pry.start
+# DO NOT COMMIT YOUR API KEY
+API_KEY = 'xxx'
+
+MailchimpAPI::Session.temp(API_KEY) { Pry.start }

--- a/lib/mailchimp_api/collection_parsers/interest_category.rb
+++ b/lib/mailchimp_api/collection_parsers/interest_category.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module MailchimpAPI::CollectionParsers
+  class InterestCategory < Base
+    protected
+
+    def element_key
+      'categories'
+    end
+  end
+end

--- a/lib/mailchimp_api/resources/interest_category.rb
+++ b/lib/mailchimp_api/resources/interest_category.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module MailchimpAPI
+  class InterestCategory < Base
+    extend MailchimpAPI::Support::Countable
+
+    self.collection_parser = CollectionParsers::InterestCategory
+
+    self.prefix = '/3.0/lists/:list_id/'
+    self.collection_name = 'interest-categories'
+
+    protected
+    
+    # This resource only accepts updates via PATCH requests, not standard ActiveResource PUT requests
+    def update
+      run_callbacks :update do
+        connection.patch(element_path(prefix_options), encode, self.class.headers).tap do |response|
+          load_attributes_from_response(response)
+        end
+      end
+    end
+  end
+end

--- a/lib/mailchimp_api/resources/interest_category.rb
+++ b/lib/mailchimp_api/resources/interest_category.rb
@@ -10,8 +10,8 @@ module MailchimpAPI
     self.collection_name = 'interest-categories'
 
     protected
-    
-    # This resource only accepts updates via PATCH requests, not standard ActiveResource PUT requests
+
+    # Overridden - This resource only accepts updates via PATCH requests, not standard ActiveResource PUT requests
     def update
       run_callbacks :update do
         connection.patch(element_path(prefix_options), encode, self.class.headers).tap do |response|

--- a/lib/mailchimp_api/resources/interest_category.rb
+++ b/lib/mailchimp_api/resources/interest_category.rb
@@ -7,6 +7,7 @@ module MailchimpAPI
     self.collection_parser = CollectionParsers::InterestCategory
 
     self.prefix = '/3.0/lists/:list_id/'
+    self.element_name = 'interest-category'
     self.collection_name = 'interest-categories'
 
     protected

--- a/lib/mailchimp_api/resources/list.rb
+++ b/lib/mailchimp_api/resources/list.rb
@@ -5,5 +5,7 @@ module MailchimpAPI
     extend MailchimpAPI::Support::Countable
 
     self.collection_parser = CollectionParsers::List
+
+    has_many :interest_categories, class_name: 'MailchimpAPI::InterestCategory'
   end
 end

--- a/lib/mailchimp_api/resources/support/countable.rb
+++ b/lib/mailchimp_api/resources/support/countable.rb
@@ -2,8 +2,10 @@
 
 module MailchimpAPI::Support
   module Countable
-    def count
-      all(params: { fields: 'total_items', count: 0 }).total_items
+    def count(params = {})
+      all_params = params.deep_merge(params: { fields: 'total_items', count: 0 })
+
+      all(all_params).total_items
     end
   end
 end

--- a/lib/mailchimp_api/version.rb
+++ b/lib/mailchimp_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MailchimpAPI
-  VERSION = '1.0.0.pre.0'
+  VERSION = '1.0.0.pre.1'
 end

--- a/test/collection_parsers/test_interest_category.rb
+++ b/test/collection_parsers/test_interest_category.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module MailchimpAPI::CollectionParsers
+  class TestBase < Test::Unit::TestCase
+    def test_element_key_is_categories
+      collection = MailchimpAPI::CollectionParsers::InterestCategory.new
+
+      assert_equal collection.send(:element_key), 'categories'
+    end
+  end
+end

--- a/test/fixtures/interest_categories.json
+++ b/test/fixtures/interest_categories.json
@@ -1,0 +1,57 @@
+{
+  "list_id": "list1234",
+  "categories": [{
+    "list_id": "list1234",
+    "id": "ic1234",
+    "title": "Pizza Toppings",
+    "display_order": 0,
+    "type": "checkboxes",
+    "_links": [{
+      "rel": "self",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/interest-categories/ic1234",
+      "method": "GET",
+      "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/Response.json"
+    }, {
+      "rel": "parent",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/interest-categories",
+      "method": "GET",
+      "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json",
+      "schema": "https://us7.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json"
+    }, {
+      "rel": "update",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/interest-categories/ic1234",
+      "method": "PATCH",
+      "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/Response.json",
+      "schema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/PATCH.json"
+    }, {
+      "rel": "delete",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/interest-categories/ic1234",
+      "method": "DELETE"
+    }, {
+      "rel": "interests",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/interest-categories/ic1234/interests",
+      "method": "GET",
+      "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json",
+      "schema": "https://us7.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"
+    }]
+  }],
+  "total_items": 1,
+  "_links": [{
+    "rel": "self",
+    "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/interest-categories",
+    "method": "GET",
+    "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json",
+    "schema": "https://us7.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json"
+  }, {
+    "rel": "parent",
+    "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/",
+    "method": "GET",
+    "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Response.json"
+  }, {
+    "rel": "create",
+    "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/interest-categories",
+    "method": "POST",
+    "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/Response.json",
+    "schema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/POST.json"
+  }]
+}

--- a/test/fixtures/interest_category.json
+++ b/test/fixtures/interest_category.json
@@ -1,0 +1,35 @@
+{
+  "list_id": "list1234",
+  "id": "ic1234",
+  "title": "Fav Pizza Toppings",
+  "display_order": 0,
+  "type": "radio",
+  "_links": [{
+    "rel": "self",
+    "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/interest-categories/ic1234",
+    "method": "GET",
+    "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/Response.json"
+  }, {
+    "rel": "parent",
+    "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/interest-categories",
+    "method": "GET",
+    "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/CollectionResponse.json",
+    "schema": "https://us7.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json"
+  }, {
+    "rel": "update",
+    "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/interest-categories/ic1234",
+    "method": "PATCH",
+    "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/Response.json",
+    "schema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/PATCH.json"
+  }, {
+    "rel": "delete",
+    "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/interest-categories/ic1234",
+    "method": "DELETE"
+  }, {
+    "rel": "interests",
+    "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/interest-categories/ic1234/interests",
+    "method": "GET",
+    "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json",
+    "schema": "https://us7.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"
+  }]
+}

--- a/test/resources/test_interest_category.rb
+++ b/test/resources/test_interest_category.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module MailchimpAPI
+  class TestInterestCategory < Test::Unit::TestCase
+    ALL_INTEREST_CATEGORIES_URL = 'https://__API_REGION_IDENTIFIER__.api.mailchimp.com/3.0/lists/list1234/interest-categories'
+    SINGLE_INTEREST_CATEGORY_URL = 'https://__API_REGION_IDENTIFIER__.api.mailchimp.com/3.0/lists/list1234/interest-categories/ic1234'
+
+    def setup
+      super
+
+      stub_request(:get, ALL_INTEREST_CATEGORIES_URL)
+        .to_return body: load_fixture(:interest_categories)
+
+      stub_request(:get, SINGLE_INTEREST_CATEGORY_URL)
+        .to_return body: load_fixture(:interest_category)
+    end
+
+    def test_requires_list_id_prefix
+      error = assert_raises ActiveResource::MissingPrefixParam do
+        MailchimpAPI::InterestCategory.all
+      end
+
+      assert_match 'list_id prefix_option is missing', error.message
+    end
+
+    def test_update_uses_patch_request
+      stub_request(:patch, SINGLE_INTEREST_CATEGORY_URL)
+        .to_return status: 200
+
+      interest_category = MailchimpAPI::InterestCategory.find 'ic1234', params: { list_id: 'list1234' }
+      interest_category.type = 'something else'
+      interest_category.save
+
+      assert_not_requested :put, SINGLE_INTEREST_CATEGORY_URL
+      assert_requested :patch, SINGLE_INTEREST_CATEGORY_URL
+    end
+
+    def test_countable
+      stub_request(:get, ALL_INTEREST_CATEGORIES_URL + '?count=0&fields=total_items')
+        .to_return body: load_fixture(:count_payload)
+
+      assert_equal 2, MailchimpAPI::InterestCategory.count(params: { list_id: 'list1234' })
+    end
+
+    def test_instantiates_proper_class
+      interest_categories = MailchimpAPI::InterestCategory.all params: { list_id: 'list1234' }
+
+      assert_kind_of MailchimpAPI::CollectionParsers::InterestCategory, interest_categories
+      assert_instance_of MailchimpAPI::InterestCategory, interest_categories.first
+    end
+  end
+end


### PR DESCRIPTION
[InterestCategories](https://developer.mailchimp.com/documentation/mailchimp/reference/lists/interest-categories/) are a sub-resource of Lists, thus a List `has_many` InterestCategories.

```
list = MailchimpAPI::List.first
category = list.interest_categories.first
```

Creating or using an InterestCategory directly requires the List ID it belongs to
```
MailchimpAPI::InterestCategory.count params: { list_id: '12345' }
```