### PR TITLE
Add more support for Tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Support of '/lists/<id>/members/<id>/notes'
 - Support of '/lists/<id>/members/<id>/tags'
 - Support of '/lists/<id>/segments'
+- Support of '/lists/<id>/segments/<id>/members'
 - Support of '/lists/<id>/merge-fields'
 - Support of '/lists/<id>/signup-forms'
 - `.count` support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mailchimp_api (1.0.0.pre.9)
+    mailchimp_api (1.0.0.pre.11)
       activeresource (~> 5.1.0)
 
 GEM
@@ -81,7 +81,7 @@ GEM
       ffi (~> 1.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     shellany (0.0.1)
     thor (0.20.3)
     thread_safe (0.3.6)

--- a/lib/mailchimp_api/collection_parsers/segment_member.rb
+++ b/lib/mailchimp_api/collection_parsers/segment_member.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module MailchimpAPI::CollectionParsers
+  class SegmentMember < Base
+    def element_key
+      'members'
+    end
+  end
+end

--- a/lib/mailchimp_api/exceptions.rb
+++ b/lib/mailchimp_api/exceptions.rb
@@ -6,4 +6,10 @@ module MailchimpAPI
       super
     end
   end
+
+  class InvalidOperation < StandardError
+    def initialize(msg = 'The requested operation is not valid')
+      super
+    end
+  end
 end

--- a/lib/mailchimp_api/resources/list.rb
+++ b/lib/mailchimp_api/resources/list.rb
@@ -12,5 +12,6 @@ module MailchimpAPI
     has_many :members,             class_name: 'MailchimpAPI::Member'
     has_many :merge_fields,        class_name: 'MailchimpAPI::MergeField'
     has_many :signup_forms,        class_name: 'MailchimpAPI::SignupForm'
+    has_many :segments,            class_name: 'MailchimpAPI::Segment'
   end
 end

--- a/lib/mailchimp_api/resources/member.rb
+++ b/lib/mailchimp_api/resources/member.rb
@@ -40,5 +40,13 @@ module MailchimpAPI
         connection.post path, nil, self.class.headers
       end
     end
+
+    # Tags should be provided as an array of the form [{name: 'tag1', status: 'active'}, {name: 'tag2', status: 'inactive'}]
+    def update_tags(tags)
+      path = element_path(prefix_options) + '/tags'
+      body = { tags: tags }.to_json
+
+      connection.post path, body, self.class.headers
+    end
   end
 end

--- a/lib/mailchimp_api/resources/segment.rb
+++ b/lib/mailchimp_api/resources/segment.rb
@@ -9,5 +9,15 @@ module MailchimpAPI
     self.collection_parser = CollectionParsers::Segment
 
     self.prefix = '/3.0/lists/:list_id/'
+
+    # The path to get segment members is '/3.0/lists/:list_id/segments/:segment_id/members'
+    # Unfortunately, ActiveResource does not support nested resources, only single parent resources:
+    #
+    # https://github.com/rails/activeresource/blob/4accda8bc03ceae0ad626f8cec0b4751e89a58ad/lib/active_resource/associations.rb#L151
+    #
+    # Using a has_many, there is no way to include the `list_id`, so we just create our own members method.
+    def members(params = {})
+      @members ||= MailchimpAPI::SegmentMember.find(:all, params: { segment_id: id }.deep_merge(prefix_options).deep_merge(params))
+    end
   end
 end

--- a/lib/mailchimp_api/resources/segment_member.rb
+++ b/lib/mailchimp_api/resources/segment_member.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module MailchimpAPI
+  class SegmentMember < Base
+    extend MailchimpAPI::Support::Countable
+
+    self.collection_parser = CollectionParsers::SegmentMember
+    self.element_name = 'member'
+    self.collection_name = 'members'
+
+    self.prefix = '/3.0/lists/:list_id/segments/:segment_id/'
+
+    def update
+      raise 'Cannot update SegmentMember. Please use POST to add to a Segment, or DELETE to remove from a Segment.'
+    end
+  end
+end

--- a/lib/mailchimp_api/resources/segment_member.rb
+++ b/lib/mailchimp_api/resources/segment_member.rb
@@ -11,7 +11,7 @@ module MailchimpAPI
     self.prefix = '/3.0/lists/:list_id/segments/:segment_id/'
 
     def update
-      raise 'Cannot update SegmentMember. Please use POST to add to a Segment, or DELETE to remove from a Segment.'
+      raise MailchimpAPI::InvalidOperation.new 'Cannot update SegmentMember. Please use POST to add to a Segment, or DELETE to remove from a Segment.'
     end
   end
 end

--- a/lib/mailchimp_api/version.rb
+++ b/lib/mailchimp_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MailchimpAPI
-  VERSION = '1.0.0.pre.9'
+  VERSION = '1.0.0.pre.11'
 end

--- a/test/fixtures/segment_members.json
+++ b/test/fixtures/segment_members.json
@@ -1,0 +1,109 @@
+{
+  "members": [{
+    "id": "s1234",
+    "email_address": "testy@rewind.io",
+    "unique_email_id": "1234",
+    "email_type": "html",
+    "status": "subscribed",
+    "merge_fields": {
+      "FNAME": "",
+      "LNAME": "",
+      "ADDRESS": "",
+      "MMERGE6": "",
+      "MMERGE7": ""
+    },
+    "stats": {
+      "avg_open_rate": 1,
+      "avg_click_rate": 1
+    },
+    "ip_signup": "",
+    "timestamp_signup": "",
+    "ip_opt": "174.112.62.168",
+    "timestamp_opt": "2019-02-21T14:44:40+00:00",
+    "member_rating": 2,
+    "last_changed": "2019-02-25T16:13:34+00:00",
+    "language": "en",
+    "vip": false,
+    "email_client": "Gmail",
+    "location": {
+      "latitude": 43.5924,
+      "longitude": -79.6953,
+      "gmtoff": -5,
+      "dstoff": -4,
+      "country_code": "CA",
+      "timezone": "America/Toronto"
+    },
+    "last_note": {
+      "note_id": 48917,
+      "created_at": "2019-02-15T16:35:59+00:00",
+      "created_by": "116200638",
+      "note": "OMG THIS GUY"
+    },
+    "list_id": "list1234",
+    "_links": [{
+      "rel": "self",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/members/s1234",
+      "method": "GET",
+      "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json"
+    }, {
+      "rel": "parent",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/members",
+      "method": "GET",
+      "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json",
+      "schema": "https://us7.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"
+    }, {
+      "rel": "update",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/members/s1234",
+      "method": "PATCH",
+      "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json",
+      "schema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json"
+    }, {
+      "rel": "upsert",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/members/s1234",
+      "method": "PUT",
+      "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json",
+      "schema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json"
+    }, {
+      "rel": "delete",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/members/s1234",
+      "method": "DELETE"
+    }, {
+      "rel": "activity",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/members/s1234/activity",
+      "method": "GET",
+      "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json"
+    }, {
+      "rel": "goals",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/members/s1234/goals",
+      "method": "GET",
+      "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json"
+    }, {
+      "rel": "notes",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/members/s1234/notes",
+      "method": "GET",
+      "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json"
+    }, {
+      "rel": "delete_permanent",
+      "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/members/s1234/actions/delete-permanent",
+      "method": "POST"
+    }]
+  }],
+  "total_items": 1,
+  "_links": [{
+    "rel": "self",
+    "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/segments/s1234/members",
+    "method": "GET",
+    "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/Members/CollectionResponse.json"
+  }, {
+    "rel": "parent",
+    "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/segments/s1234",
+    "method": "GET",
+    "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/Response.json"
+  }, {
+    "rel": "create",
+    "href": "https://us7.api.mailchimp.com/3.0/lists/list1234/segments/s1234/members",
+    "method": "POST",
+    "targetSchema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/Members/Response.json",
+    "schema": "https://us7.api.mailchimp.com/schema/3.0/Definitions/Lists/Segments/Members/POST.json"
+  }]
+}

--- a/test/resources/test_member.rb
+++ b/test/resources/test_member.rb
@@ -106,4 +106,19 @@ describe MailchimpAPI::Member do
       assert_requested :post, MEMBER_ACTION_URL + '/delete-permanent'
     end
   end
+
+  describe 'update_tags' do
+    let(:member) { MailchimpAPI::Member.find 'm1234', params: { list_id: 'list1234' } }
+
+    before do
+      stub_request(:post, SINGLE_MEMBER_URL + '/tags')
+        .to_return status: 204, body: nil
+    end
+
+    it 'should send body as json' do
+      member.update_tags [{ name: 'hi', status: 'active' }]
+
+      assert_requested :post, SINGLE_MEMBER_URL + '/tags', body: '{"tags":[{"name":"hi","status":"active"}]}'
+    end
+  end
 end

--- a/test/resources/test_segment_member.rb
+++ b/test/resources/test_segment_member.rb
@@ -37,7 +37,7 @@ describe MailchimpAPI::SegmentMember do
     it 'is not supported' do
       segment_member = MailchimpAPI::SegmentMember.first params: { list_id: 'list1234', segment_id: 's1234' }
       error =
-        assert_raises do
+        assert_raises MailchimpAPI::InvalidOperation do
           segment_member.email_address = 'nope'
           segment_member.save
         end

--- a/test/resources/test_segment_member.rb
+++ b/test/resources/test_segment_member.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe MailchimpAPI::SegmentMember do
+  ALL_SEGMENT_MEMBERS_URL = 'https://__API_REGION_IDENTIFIER__.api.mailchimp.com/3.0/lists/list1234/segments/s1234/members'
+
+  let(:segment_members) { MailchimpAPI::SegmentMember.all params: { list_id: 'list1234', segment_id: 's1234'  } }
+
+  before do
+    stub_request(:get, ALL_SEGMENT_MEMBERS_URL)
+      .to_return body: load_fixture(:segment_members)
+  end
+
+  it 'instantiates the class properly' do
+    assert_kind_of MailchimpAPI::CollectionParsers::SegmentMember, segment_members
+    assert_instance_of MailchimpAPI::SegmentMember, segment_members.first
+  end
+
+  it 'requires list_id prefix' do
+    error = assert_raises ActiveResource::MissingPrefixParam do
+      MailchimpAPI::SegmentMember.all
+    end
+
+    assert_match 'list_id prefix_option is missing', error.message
+  end
+
+  it 'requires segment_id prefix' do
+    error = assert_raises ActiveResource::MissingPrefixParam do
+      MailchimpAPI::SegmentMember.all params: { list_id: 'list1234' }
+    end
+
+    assert_match 'segment_id prefix_option is missing', error.message
+  end
+
+  describe 'update' do
+    it 'is not supported' do
+      segment_member = MailchimpAPI::SegmentMember.first params: { list_id: 'list1234', segment_id: 's1234' }
+      error =
+        assert_raises do
+          segment_member.email_address = 'nope'
+          segment_member.save
+        end
+
+      assert_match 'Cannot update SegmentMember. Please use POST to add to a Segment, or DELETE to remove from a Segment.', error.message
+    end
+  end
+end


### PR DESCRIPTION
Adding `update_tags` on Member object as [the endpoint is not RESTful/AR-friendly](https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/tags/)

Adding Segments relationship to Lists, and giving Segments a `members` method to help add/remove Members from a Segment. The endpoint is [almost RESTful/AR-friendly](https://developer.mailchimp.com/documentation/mailchimp/reference/lists/segments/members/).