### PR TITLE
Add support for enumerable resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 - Support of '/lists/<id>/signup-forms'
 - `.count` support
 - `exists?` support
+- `enumerator` support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    mailchimp_api (1.0.0.pre.11)
+    mailchimp_api (1.0.0.pre.12)
       activeresource (~> 5.1.0)
+      caching_enumerator (~> 0.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -27,6 +28,7 @@ GEM
     ansi (1.5.0)
     builder (3.2.3)
     byebug (10.0.2)
+    caching_enumerator (0.0.1)
     coderay (1.1.2)
     concurrent-ruby (1.1.4)
     crack (0.4.3)

--- a/lib/mailchimp_api.rb
+++ b/lib/mailchimp_api.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift File.dirname(__FILE__)
 
 # gem requires
 require 'activeresource'
+require 'caching_enumerator'
 
 # gem extensions
 require 'active_resource/connection_ext'

--- a/lib/mailchimp_api/resources/merge_field.rb
+++ b/lib/mailchimp_api/resources/merge_field.rb
@@ -3,6 +3,7 @@
 module MailchimpAPI
   class MergeField < Base
     extend MailchimpAPI::Support::Countable
+    extend MailchimpAPI::Support::Enumerable
 
     include MailchimpAPI::Support::PatchUpdate
 

--- a/lib/mailchimp_api/resources/support/enumerable.rb
+++ b/lib/mailchimp_api/resources/support/enumerable.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module MailchimpAPI::Support
+  module Enumerable
+    def enumerator(page_size: 10, params: {})
+      CachingEnumerator.new do |y|
+        number_of_items = count params: params
+        number_of_pages = (number_of_items / page_size).ceil
+        current_page = 0
+
+        loop do
+          all_params = {
+            offset: current_page * page_size,
+            count: page_size
+          }.merge(params)
+
+          results = find :all, params: all_params
+          current_page += 1
+
+          results.each do |result|
+            y.yield result
+          end
+
+          break if results.empty? || (current_page >= number_of_pages)
+        end
+      end
+    end
+  end
+end

--- a/lib/mailchimp_api/version.rb
+++ b/lib/mailchimp_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MailchimpAPI
-  VERSION = '1.0.0.pre.11'
+  VERSION = '1.0.0.pre.12'
 end

--- a/mailchimp_api.gemspec
+++ b/mailchimp_api.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z lib`.split("\x0") + %w[CHANGELOG.md LICENSE README.md]
 
   spec.add_runtime_dependency 'activeresource', '~> 5.1.0'
+  spec.add_runtime_dependency 'caching_enumerator', '~> 0.0.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0.1'
   spec.add_development_dependency 'rake', '~> 12.3.2'

--- a/test/resources/support/test_enumerable.rb
+++ b/test/resources/support/test_enumerable.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe MailchimpAPI::Support::Enumerable do
+  it 'yields all values' do
+    stub_request(:get, 'https://__api_region_identifier__.api.mailchimp.com/3.0/lists/list1234/merge-fields?count=10&offset=0')
+      .to_return body: load_fixture(:merge_fields)
+
+    stub_request(:get, 'https://__api_region_identifier__.api.mailchimp.com/3.0/lists/list1234/merge-fields?count=0&fields=total_items')
+      .to_return body: '{"total_items": 5}'
+
+    yield_count = 0
+    MailchimpAPI::MergeField.enumerator(params: { list_id: 'list1234' }).each { yield_count += 1 }
+
+    assert_equal 5, yield_count
+  end
+
+  it 'respects pagination' do
+    stub_request(:get, 'https://__api_region_identifier__.api.mailchimp.com/3.0/lists/list1234/merge-fields?count=2&offset=0')
+      .to_return body: load_fixture(:merge_fields)
+    stub_request(:get, 'https://__api_region_identifier__.api.mailchimp.com/3.0/lists/list1234/merge-fields?count=2&offset=2')
+      .to_return body: load_fixture(:merge_fields)
+    stub_request(:get, 'https://__api_region_identifier__.api.mailchimp.com/3.0/lists/list1234/merge-fields?count=2&offset=4')
+      .to_return body: load_fixture(:merge_fields)
+
+    stub_request(:get, 'https://__api_region_identifier__.api.mailchimp.com/3.0/lists/list1234/merge-fields?count=0&fields=total_items')
+      .to_return body: '{"total_items": 6}'
+
+    MailchimpAPI::MergeField.enumerator(page_size: 2, params: { list_id: 'list1234' }).each {}
+
+    assert_requested :get, 'https://__api_region_identifier__.api.mailchimp.com/3.0/lists/list1234/merge-fields?count=2&offset=0', times: 1
+    assert_requested :get, 'https://__api_region_identifier__.api.mailchimp.com/3.0/lists/list1234/merge-fields?count=2&offset=2', times: 1
+    assert_requested :get, 'https://__api_region_identifier__.api.mailchimp.com/3.0/lists/list1234/merge-fields?count=2&offset=4', times: 1
+    assert_not_requested :get, 'https://__api_region_identifier__.api.mailchimp.com/3.0/lists/list1234/merge-fields?count=2&offset=6'
+  end
+end


### PR DESCRIPTION
Provides an enumerator on a Mailchimp resource allowing all the goodness you expect. I could not find any built-in way in AR to do this.

Uses CachingEnumerator (which is tiny) to reduce network calls to the bare minimum.