### PR TITLE
Stop monkey-patching if a connection class can be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [1.10.0]
+
+### Added
+- For newer versions of ActiveResoure, we will set the `connection_class` instead of monkey-patching ::Connection
+
 ## [1.9.0]
 
 ### Added

--- a/lib/mailchimp_api.rb
+++ b/lib/mailchimp_api.rb
@@ -6,9 +6,6 @@ $LOAD_PATH.unshift File.dirname(__FILE__)
 require 'activeresource'
 require 'caching_enumerator'
 
-# gem extensions
-require 'active_resource/connection_ext'
-
 require 'mailchimp_api/version'
 require 'mailchimp_api/configuration'
 
@@ -23,3 +20,9 @@ require 'mailchimp_api/session'
 
 require 'mailchimp_api/collection_parsers'
 require 'mailchimp_api/resources'
+
+if MailchimpAPI::Base.respond_to?(:connection_class)
+  MailchimpAPI::Base.connection_class = MailchimpAPI::Connection
+else
+  require 'active_resource/connection_ext'
+end

--- a/lib/mailchimp_api/version.rb
+++ b/lib/mailchimp_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MailchimpAPI
-  VERSION = '1.9.0'
+  VERSION = '1.10.0'
 end


### PR DESCRIPTION
This PR removes the monkey-patch of ActiveResource::Connection if we are able to set the connection_class to our MailchimpAPI::Connection.

This allows for multiple ActiveResource based gems to run without the connection class being overwritten by each one.